### PR TITLE
feat: 좌석 예약 api 구현

### DIFF
--- a/src/main/java/concertreservation/common/exception/ErrorType.java
+++ b/src/main/java/concertreservation/common/exception/ErrorType.java
@@ -10,8 +10,9 @@ public enum ErrorType {
     NOT_FOUND_USER(404,"회원을 찾을수 없습니다."),
     NOT_FOUND_CONCERT(404,"콘서트를 찾을수 없습니다."),
     NOT_FOUND_CONCERT_SCHEDULE(404,"콘서트를 찾을수 없습니다."),
+    NOT_FOUND_CONCERT_SEAT(404,"좌석을 찾을수 없습니다."),
     NOT_FOUNT_CONCERT_SCHEDULE_SEAT(404,"해당 콘서트 스케줄에 좌석을 찾을수 없습니다."),
-    NOT_AVAILABLE_SEAT(400, "예약 가능한 좌석이 아닙니다.")
+    ALREADY_RESERVED_SEAT(400, "이미 예약된 좌석입니다.")
     ;
 
     private final int status;

--- a/src/main/java/concertreservation/common/exception/ErrorType.java
+++ b/src/main/java/concertreservation/common/exception/ErrorType.java
@@ -9,7 +9,9 @@ public enum ErrorType {
 
     NOT_FOUND_USER(404,"회원을 찾을수 없습니다."),
     NOT_FOUND_CONCERT(404,"콘서트를 찾을수 없습니다."),
-    NOT_FOUND_CONCERT_SCHEDULE(404,"콘서트를 찾을수 없습니다.")
+    NOT_FOUND_CONCERT_SCHEDULE(404,"콘서트를 찾을수 없습니다."),
+    NOT_FOUNT_CONCERT_SCHEDULE_SEAT(404,"해당 콘서트 스케줄에 좌석을 찾을수 없습니다."),
+    NOT_AVAILABLE_SEAT(400, "예약 가능한 좌석이 아닙니다.")
     ;
 
     private final int status;

--- a/src/main/java/concertreservation/common/handler/CustomExceptionHandler.java
+++ b/src/main/java/concertreservation/common/handler/CustomExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,6 +21,16 @@ public class CustomExceptionHandler {
         return ResponseEntity
                 .status(httpStatus.value())
                 .body(new ExceptionResponse(httpStatus.value(), httpStatus, e.getMessage()));
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<?> apiExceptionHandler(ObjectOptimisticLockingFailureException e) {
+        ErrorType errorType = ErrorType.ALREADY_RESERVED_SEAT;
+        HttpStatus httpStatus = HttpStatus.valueOf(errorType.getStatus());
+
+        return ResponseEntity
+                .status(httpStatus.value())
+                .body(new ExceptionResponse(httpStatus.value(), httpStatus, errorType.getMessage()));
     }
 
     @Getter

--- a/src/main/java/concertreservation/concert/entity/Concert.java
+++ b/src/main/java/concertreservation/concert/entity/Concert.java
@@ -2,6 +2,7 @@ package concertreservation.concert.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +20,13 @@ public class Concert {
     private String title;
     private String name;
     private String imageUrl;
+
+    @Builder
+    public Concert(String title, String name, String imageUrl) {
+        this.title = title;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
 
     public static Concert create(String title, String name, String imageUrl) {
         Concert concert = new Concert();

--- a/src/main/java/concertreservation/concert/entity/ConcertSchedule.java
+++ b/src/main/java/concertreservation/concert/entity/ConcertSchedule.java
@@ -2,6 +2,7 @@ package concertreservation.concert.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,6 +21,12 @@ public class ConcertSchedule {
 
     private Long concertId;
     private LocalDate concertDate;
+
+    @Builder
+    public ConcertSchedule(Long concertId, LocalDate concertDate) {
+        this.concertId = concertId;
+        this.concertDate = concertDate;
+    }
 
     public static ConcertSchedule create(Long concertId, LocalDate concertDate) {
         ConcertSchedule concertSchedule = new ConcertSchedule();

--- a/src/main/java/concertreservation/concert/entity/Seat.java
+++ b/src/main/java/concertreservation/concert/entity/Seat.java
@@ -31,4 +31,12 @@ public class Seat {
         seat.seatPrice = seatPrice;
         return seat;
     }
+
+    public boolean isAvailableSeat(){
+        return this.seatStatus == SeatStatus.AVAILABLE;
+    }
+
+    public void updateSeatStatus(SeatStatus seatStatus){
+        this.seatStatus = SeatStatus.RESERVED;
+    }
 }

--- a/src/main/java/concertreservation/concert/entity/Seat.java
+++ b/src/main/java/concertreservation/concert/entity/Seat.java
@@ -23,6 +23,16 @@ public class Seat {
     private SeatStatus seatStatus;
     private int seatPrice;
 
+    @Version
+    private Long version;
+
+    public Seat(Long concertScheduleId, String seatNumber, SeatStatus seatStatus, int seatPrice) {
+        this.concertScheduleId = concertScheduleId;
+        this.seatNumber = seatNumber;
+        this.seatStatus = seatStatus;
+        this.seatPrice = seatPrice;
+    }
+
     public static Seat create(Long concertScheduleId, String seatNumber, int seatPrice) {
         Seat seat = new Seat();
         seat.concertScheduleId = concertScheduleId;
@@ -37,6 +47,6 @@ public class Seat {
     }
 
     public void updateSeatStatus(SeatStatus seatStatus){
-        this.seatStatus = SeatStatus.RESERVED;
+        this.seatStatus = seatStatus;
     }
 }

--- a/src/main/java/concertreservation/concert/repository/ConcertRepositoryImpl.java
+++ b/src/main/java/concertreservation/concert/repository/ConcertRepositoryImpl.java
@@ -17,4 +17,9 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     public Optional<Concert> findById(Long concertId) {
         return concertJpaRepository.findById(concertId);
     }
+
+    @Override
+    public Concert save(Concert concert) {
+        return concertJpaRepository.save(concert);
+    }
 }

--- a/src/main/java/concertreservation/concert/repository/ConcertScheduleRepositoryImpl.java
+++ b/src/main/java/concertreservation/concert/repository/ConcertScheduleRepositoryImpl.java
@@ -23,4 +23,9 @@ public class ConcertScheduleRepositoryImpl implements ConcertScheduleRepository 
     public Optional<ConcertSchedule> findById(Long concertScheduleId) {
         return concertScheduleJpaRepository.findById(concertScheduleId);
     }
+
+    @Override
+    public ConcertSchedule save(ConcertSchedule concertSchedule) {
+        return concertScheduleJpaRepository.save(concertSchedule);
+    }
 }

--- a/src/main/java/concertreservation/concert/repository/SeatJpaRepository.java
+++ b/src/main/java/concertreservation/concert/repository/SeatJpaRepository.java
@@ -5,7 +5,9 @@ import concertreservation.concert.entity.SeatStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
-public interface SeatJpaRepository extends JpaRepository<Seat,Long> {
+public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByConcertScheduleIdAndSeatStatus(Long concertScheduleId, SeatStatus seatStatus);
+    Optional<Seat> findByIdAndConcertScheduleId(Long seatId, Long concertScheduleId);
 }

--- a/src/main/java/concertreservation/concert/repository/SeatJpaRepository.java
+++ b/src/main/java/concertreservation/concert/repository/SeatJpaRepository.java
@@ -2,7 +2,12 @@ package concertreservation.concert.repository;
 
 import concertreservation.concert.entity.Seat;
 import concertreservation.concert.entity.SeatStatus;
+import concertreservation.user.service.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +15,12 @@ import java.util.Optional;
 public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByConcertScheduleIdAndSeatStatus(Long concertScheduleId, SeatStatus seatStatus);
     Optional<Seat> findByIdAndConcertScheduleId(Long seatId, Long concertScheduleId);
+
+    @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+    @Query("select s from Seat s where s.id = :id")
+    Optional<Seat> findByIdWithOptimisticLock(@Param("id") Long seatId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Seat s where s.id = :id")
+    Optional<Seat> findByIdWithPessimisticLock(@Param("id") Long seatId);
 }

--- a/src/main/java/concertreservation/concert/repository/SeatRepositoryImpl.java
+++ b/src/main/java/concertreservation/concert/repository/SeatRepositoryImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,5 +18,10 @@ public class SeatRepositoryImpl implements SeatRepository {
     @Override
     public List<Seat> findByConcertScheduleIdAndSeatStatus(Long concertScheduleId, SeatStatus seatStatus) {
         return seatJpaRepository.findByConcertScheduleIdAndSeatStatus(concertScheduleId, seatStatus);
+    }
+
+    @Override
+    public Optional<Seat> findByIdAndConcertScheduleId(Long concertScheduleId, Long seatId) {
+        return seatJpaRepository.findByIdAndConcertScheduleId(concertScheduleId, seatId);
     }
 }

--- a/src/main/java/concertreservation/concert/repository/SeatRepositoryImpl.java
+++ b/src/main/java/concertreservation/concert/repository/SeatRepositoryImpl.java
@@ -24,4 +24,19 @@ public class SeatRepositoryImpl implements SeatRepository {
     public Optional<Seat> findByIdAndConcertScheduleId(Long concertScheduleId, Long seatId) {
         return seatJpaRepository.findByIdAndConcertScheduleId(concertScheduleId, seatId);
     }
+
+    @Override
+    public Seat save(Seat seat) {
+        return seatJpaRepository.save(seat);
+    }
+
+    @Override
+    public Optional<Seat> findByIdWithOptimisticLock(Long seatId) {
+        return seatJpaRepository.findByIdWithOptimisticLock(seatId);
+    }
+
+    @Override
+    public Optional<Seat> findByIdWithPessimistic(Long seatId) {
+        return seatJpaRepository.findByIdWithPessimisticLock(seatId);
+    }
 }

--- a/src/main/java/concertreservation/concert/service/ConcertRepository.java
+++ b/src/main/java/concertreservation/concert/service/ConcertRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 public interface ConcertRepository {
 
     Optional<Concert> findById(Long concertId);
+    Concert save(Concert concert);
 }

--- a/src/main/java/concertreservation/concert/service/ConcertScheduleRepository.java
+++ b/src/main/java/concertreservation/concert/service/ConcertScheduleRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface ConcertScheduleRepository {
     List<ConcertSchedule> findByConcertId(Long concertId);
     Optional<ConcertSchedule> findById(Long concertScheduleId);
+    ConcertSchedule save(ConcertSchedule concertSchedule);
 }

--- a/src/main/java/concertreservation/concert/service/SeatRepository.java
+++ b/src/main/java/concertreservation/concert/service/SeatRepository.java
@@ -2,6 +2,7 @@ package concertreservation.concert.service;
 
 import concertreservation.concert.entity.Seat;
 import concertreservation.concert.entity.SeatStatus;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +10,7 @@ import java.util.Optional;
 public interface SeatRepository {
     List<Seat> findByConcertScheduleIdAndSeatStatus(Long concertScheduleId, SeatStatus seatStatus);
     Optional<Seat> findByIdAndConcertScheduleId(Long concertScheduleId, Long seatId);
+    Seat save(Seat seat);
+    Optional<Seat> findByIdWithOptimisticLock(Long seatId);
+    Optional<Seat> findByIdWithPessimistic(Long seatId);
 }

--- a/src/main/java/concertreservation/concert/service/SeatRepository.java
+++ b/src/main/java/concertreservation/concert/service/SeatRepository.java
@@ -4,7 +4,9 @@ import concertreservation.concert.entity.Seat;
 import concertreservation.concert.entity.SeatStatus;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SeatRepository {
     List<Seat> findByConcertScheduleIdAndSeatStatus(Long concertScheduleId, SeatStatus seatStatus);
+    Optional<Seat> findByIdAndConcertScheduleId(Long concertScheduleId, Long seatId);
 }

--- a/src/main/java/concertreservation/concert/service/response/ConcertAvailableSeatResponse.java
+++ b/src/main/java/concertreservation/concert/service/response/ConcertAvailableSeatResponse.java
@@ -1,0 +1,21 @@
+package concertreservation.concert.service.response;
+
+import concertreservation.concert.entity.Seat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ConcertAvailableSeatResponse {
+
+    private List<String> seatNumber;
+
+    public static ConcertAvailableSeatResponse from(List<Seat> seats) {
+        List<String> seatNumbers = seats.stream()
+                .map(Seat::getSeatNumber)
+                .toList();
+        return new ConcertAvailableSeatResponse(seatNumbers);
+    }
+}

--- a/src/main/java/concertreservation/reservation/controller/ReservationController.java
+++ b/src/main/java/concertreservation/reservation/controller/ReservationController.java
@@ -1,0 +1,21 @@
+package concertreservation.reservation.controller;
+
+import concertreservation.reservation.controller.request.ConcertSeatReservationRequest;
+import concertreservation.reservation.service.ReservationService;
+import concertreservation.reservation.service.response.ReservationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @PostMapping("/concerts/reservation")
+    public ReservationResponse reservation(@RequestBody ConcertSeatReservationRequest request){
+        return reservationService.reservation(request.getUserId(), request.getConcertScheduleId(), request.getSeatId());
+    }
+}

--- a/src/main/java/concertreservation/reservation/controller/request/ConcertSeatReservationRequest.java
+++ b/src/main/java/concertreservation/reservation/controller/request/ConcertSeatReservationRequest.java
@@ -1,0 +1,14 @@
+package concertreservation.reservation.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConcertSeatReservationRequest {
+    private Long userId;
+    private Long concertScheduleId;
+    private Long seatId;
+}

--- a/src/main/java/concertreservation/reservation/entity/Reservation.java
+++ b/src/main/java/concertreservation/reservation/entity/Reservation.java
@@ -1,0 +1,52 @@
+package concertreservation.reservation.entity;
+
+import concertreservation.concert.entity.Concert;
+import concertreservation.concert.entity.ConcertSchedule;
+import concertreservation.reservation.service.response.ReservationResponse;
+import concertreservation.user.service.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "reservations")
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private Long seatId;
+    private String concertTitle;
+    private String seatNumber;
+    private int reservationPoint;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus reservationStatus;
+    private LocalDateTime expiredAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static Reservation create(Long userId, Long seatId, int reservationPoint, String concertTitle, String seatNumber) {
+        LocalDateTime now = LocalDateTime.now();
+
+        Reservation reservation = new Reservation();
+        reservation.userId = userId;
+        reservation.seatId = seatId;
+        reservation.concertTitle = concertTitle;
+        reservation.seatNumber = seatNumber;
+        reservation.reservationPoint = reservationPoint;
+        reservation.reservationStatus = ReservationStatus.RESERVED;
+        reservation.expiredAt = now.plusMinutes(5);
+        reservation.createdAt = now;
+        reservation.modifiedAt = now;
+        return reservation;
+    }
+}

--- a/src/main/java/concertreservation/reservation/entity/ReservationStatus.java
+++ b/src/main/java/concertreservation/reservation/entity/ReservationStatus.java
@@ -1,0 +1,16 @@
+package concertreservation.reservation.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReservationStatus {
+
+    RESERVED("예약됨"),
+    PAID("결제됨"),
+    EXPIRED("만료됨")
+    ;
+
+    private final String content;
+}

--- a/src/main/java/concertreservation/reservation/repository/ReservationJpaRepository.java
+++ b/src/main/java/concertreservation/reservation/repository/ReservationJpaRepository.java
@@ -1,0 +1,7 @@
+package concertreservation.reservation.repository;
+
+import concertreservation.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationJpaRepository extends JpaRepository<Reservation,Long> {
+}

--- a/src/main/java/concertreservation/reservation/repository/ReservationJpaRepository.java
+++ b/src/main/java/concertreservation/reservation/repository/ReservationJpaRepository.java
@@ -3,5 +3,8 @@ package concertreservation.reservation.repository;
 import concertreservation.reservation.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReservationJpaRepository extends JpaRepository<Reservation,Long> {
+    Optional<Reservation> findBySeatId(Long seatId);
 }

--- a/src/main/java/concertreservation/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/concertreservation/reservation/repository/ReservationRepositoryImpl.java
@@ -1,0 +1,18 @@
+package concertreservation.reservation.repository;
+
+import concertreservation.reservation.entity.Reservation;
+import concertreservation.reservation.service.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReservationRepositoryImpl implements ReservationRepository {
+
+    private final ReservationJpaRepository reservationJpaRepository;
+
+    @Override
+    public Reservation save(Reservation reservation) {
+        return reservationJpaRepository.save(reservation);
+    }
+}

--- a/src/main/java/concertreservation/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/concertreservation/reservation/repository/ReservationRepositoryImpl.java
@@ -5,6 +5,8 @@ import concertreservation.reservation.service.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class ReservationRepositoryImpl implements ReservationRepository {
@@ -14,5 +16,10 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     @Override
     public Reservation save(Reservation reservation) {
         return reservationJpaRepository.save(reservation);
+    }
+
+    @Override
+    public Optional<Reservation> findBySeatId(Long seatId) {
+        return reservationJpaRepository.findBySeatId(seatId);
     }
 }

--- a/src/main/java/concertreservation/reservation/service/ReservationRepository.java
+++ b/src/main/java/concertreservation/reservation/service/ReservationRepository.java
@@ -1,0 +1,7 @@
+package concertreservation.reservation.service;
+
+import concertreservation.reservation.entity.Reservation;
+
+public interface ReservationRepository {
+    Reservation save(Reservation reservation);
+}

--- a/src/main/java/concertreservation/reservation/service/ReservationRepository.java
+++ b/src/main/java/concertreservation/reservation/service/ReservationRepository.java
@@ -2,6 +2,9 @@ package concertreservation.reservation.service;
 
 import concertreservation.reservation.entity.Reservation;
 
+import java.util.Optional;
+
 public interface ReservationRepository {
     Reservation save(Reservation reservation);
+    Optional<Reservation> findBySeatId(Long seatId);
 }

--- a/src/main/java/concertreservation/reservation/service/ReservationService.java
+++ b/src/main/java/concertreservation/reservation/service/ReservationService.java
@@ -1,0 +1,52 @@
+package concertreservation.reservation.service;
+
+import concertreservation.common.exception.CustomGlobalException;
+import concertreservation.common.exception.ErrorType;
+import concertreservation.concert.entity.Concert;
+import concertreservation.concert.entity.ConcertSchedule;
+import concertreservation.concert.entity.Seat;
+import concertreservation.concert.entity.SeatStatus;
+import concertreservation.concert.service.ConcertRepository;
+import concertreservation.concert.service.ConcertScheduleRepository;
+import concertreservation.concert.service.SeatRepository;
+import concertreservation.reservation.entity.Reservation;
+import concertreservation.reservation.service.response.ReservationResponse;
+import concertreservation.user.service.UserRepository;
+import concertreservation.user.service.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final UserRepository userRepository;
+    private final ConcertRepository concertRepository;
+    private final ConcertScheduleRepository concertScheduleRepository;
+    private final ReservationRepository reservationRepository;
+    private final SeatRepository seatRepository;
+
+    @Transactional
+    public ReservationResponse reservation(Long userId, Long concertScheduleId, Long seatId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomGlobalException(ErrorType.NOT_FOUND_USER));
+        ConcertSchedule concertSchedule = concertScheduleRepository.findById(concertScheduleId)
+                .orElseThrow(() -> new CustomGlobalException(ErrorType.NOT_FOUND_CONCERT_SCHEDULE));
+        Concert concert = concertRepository.findById(concertSchedule.getConcertId())
+                .orElseThrow(() -> new CustomGlobalException(ErrorType.NOT_FOUND_CONCERT));
+        Seat seat = seatRepository.findByIdAndConcertScheduleId(seatId, concertScheduleId)
+                .orElseThrow(() -> new CustomGlobalException(ErrorType.NOT_FOUNT_CONCERT_SCHEDULE_SEAT));
+
+
+        if (!seat.isAvailableSeat()) {
+            throw new CustomGlobalException(ErrorType.NOT_AVAILABLE_SEAT);
+        }
+
+        Reservation reservation = Reservation.create(userId, seatId, seat.getSeatPrice(),concert.getTitle(),seat.getSeatNumber());
+        reservationRepository.save(reservation);
+        seat.updateSeatStatus(SeatStatus.RESERVED);
+
+        return ReservationResponse.from(reservation,concert,concertSchedule,user,seat);
+    }
+}

--- a/src/main/java/concertreservation/reservation/service/response/ReservationResponse.java
+++ b/src/main/java/concertreservation/reservation/service/response/ReservationResponse.java
@@ -1,0 +1,41 @@
+package concertreservation.reservation.service.response;
+
+import concertreservation.concert.entity.Concert;
+import concertreservation.concert.entity.ConcertSchedule;
+import concertreservation.concert.entity.Seat;
+import concertreservation.reservation.entity.Reservation;
+import concertreservation.user.service.entity.User;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class ReservationResponse {
+
+    private Long userId;
+    private String username;
+    private Long concertId;
+    private String title;
+    private String singerName;
+    private LocalDate concertDate;
+    private String seatNumber;
+    private int seatPrice;
+    private LocalDateTime reservationExpireTime;
+    private LocalDateTime createdAt;
+
+    public static ReservationResponse from(Reservation reservation, Concert concert, ConcertSchedule concertSchedule, User user, Seat seat) {
+        ReservationResponse response = new ReservationResponse();
+        response.userId = user.getId();
+        response.username = user.getName();
+        response.concertId = concert.getId();
+        response.title = concert.getTitle();
+        response.singerName = concert.getName();
+        response.concertDate = concertSchedule.getConcertDate();
+        response.seatNumber = seat.getSeatNumber();
+        response.seatPrice = seat.getSeatPrice();
+        response.reservationExpireTime = reservation.getExpiredAt();
+        response.createdAt = reservation.getCreatedAt();
+        return response;
+    }
+}

--- a/src/test/java/concertreservation/concert/service/ConcertServiceTest.java
+++ b/src/test/java/concertreservation/concert/service/ConcertServiceTest.java
@@ -88,11 +88,11 @@ class ConcertServiceTest {
         ConcertSchedule concertSchedule = new ConcertSchedule(1L, concertId, firstDate);
 
         List<Seat> seats = List.of(
-                new Seat(1L, concertScheduleId, "1", SeatStatus.AVAILABLE, 50000),
-                new Seat(2L, concertScheduleId, "10", SeatStatus.AVAILABLE, 50000),
-                new Seat(3L, concertScheduleId, "15", SeatStatus.AVAILABLE, 50000),
-                new Seat(4L, concertScheduleId, "19", SeatStatus.AVAILABLE, 50000),
-                new Seat(5L, concertScheduleId, "20", SeatStatus.AVAILABLE, 50000)
+                new Seat(1L, concertScheduleId, "1", SeatStatus.AVAILABLE, 50000,null),
+                new Seat(2L, concertScheduleId, "10", SeatStatus.AVAILABLE, 50000,null),
+                new Seat(3L, concertScheduleId, "15", SeatStatus.AVAILABLE, 50000,null),
+                new Seat(4L, concertScheduleId, "19", SeatStatus.AVAILABLE, 50000,null),
+                new Seat(5L, concertScheduleId, "20", SeatStatus.AVAILABLE, 50000,null)
         );
         given(concertScheduleRepository.findById(concertScheduleId))
                 .willReturn(Optional.of(concertSchedule));

--- a/src/test/java/concertreservation/reservation/service/ReservationServiceConcurrencyTest.java
+++ b/src/test/java/concertreservation/reservation/service/ReservationServiceConcurrencyTest.java
@@ -1,0 +1,175 @@
+package concertreservation.reservation.service;
+
+import concertreservation.concert.entity.Concert;
+import concertreservation.concert.entity.ConcertSchedule;
+import concertreservation.concert.entity.Seat;
+import concertreservation.concert.entity.SeatStatus;
+import concertreservation.concert.service.ConcertRepository;
+import concertreservation.concert.service.ConcertScheduleRepository;
+import concertreservation.concert.service.SeatRepository;
+import concertreservation.user.service.UserRepository;
+import concertreservation.user.service.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ReservationServiceConcurrencyTest {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ConcertRepository concertRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private ConcertScheduleRepository concertScheduleRepository;
+
+    @Autowired
+    private SeatRepository seatRepository;
+
+    private static final int numberOfThreads = 100;
+
+    @BeforeEach
+    void setUp() {
+        for (int i = 0; i < numberOfThreads; i++) {
+            userRepository.save(new User("이름" + i, "번호" + i, 50000));
+        }
+    }
+
+    @Test
+    @DisplayName("유저 100명이 하나의 콘서트를 예약할때 예약은 1개만 이루어져야 한다.")
+    void reservationConcurrencyWithOptimistic() throws InterruptedException {
+        //given
+        long startTime = System.currentTimeMillis();
+
+        long concertId = 1L;
+        long concertScheduleId = 1L;
+        long seatId = 1L;
+        concertRepository.save(new Concert("콘서트1", "에스파", "https://"));
+        concertScheduleRepository.save(new ConcertSchedule(concertId, LocalDate.of(2025, 1, 15)));
+        seatRepository.save(new Seat(concertScheduleId, "A1", SeatStatus.AVAILABLE, 50000));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successfulReservations = new AtomicInteger(0);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            Long userId = (long) i;
+            executorService.submit(() -> {
+                try {
+                    reservationService.reservation(userId, concertScheduleId, seatId);
+                    successfulReservations.incrementAndGet();
+                }finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        //when
+        //then
+        long endTime = System.currentTimeMillis();
+        System.out.println("테스트 실행 시간: " + (endTime - startTime) + "ms");
+        assertThat(successfulReservations.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("유저 100명이 하나의 콘서트를 예약할때 예약은 1개만 이루어져야 한다.")
+    void reservationConcurrencyWithPessimistic() throws InterruptedException {
+        //given
+        long startTime = System.currentTimeMillis();
+
+        long concertId = 1L;
+        long concertScheduleId = 1L;
+        long seatId = 1L;
+        concertRepository.save(new Concert("콘서트1", "에스파", "https://"));
+        concertScheduleRepository.save(new ConcertSchedule(concertId, LocalDate.of(2025, 1, 15)));
+        seatRepository.save(new Seat(concertScheduleId, "A1", SeatStatus.AVAILABLE, 50000));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successfulReservations = new AtomicInteger(0);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            Long userId = (long) i;
+            executorService.submit(() -> {
+                try {
+                    reservationService.reservationPessimistic(userId, concertScheduleId, seatId);
+                    successfulReservations.incrementAndGet();
+                }finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        //when
+        //then
+        long endTime = System.currentTimeMillis();
+        System.out.println("테스트 실행 시간: " + (endTime - startTime) + "ms");
+        assertThat(successfulReservations.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("유저 100명이 하나의 콘서트를 예약할때 예외가 발생해야 한다")
+    void reservationConcurrencyWithOptimistic1() throws InterruptedException {
+        //given
+        long concertId = 1L;
+        long concertScheduleId = 1L;
+        long seatId = 1L;
+        concertRepository.save(new Concert("콘서트1", "에스파", "https://"));
+        concertScheduleRepository.save(new ConcertSchedule(concertId, LocalDate.of(2025, 1, 15)));
+        seatRepository.save(new Seat(concertScheduleId, "A1", SeatStatus.AVAILABLE, 50000));
+
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        AtomicInteger successfulReservations = new AtomicInteger(0);
+        AtomicInteger failedReservations = new AtomicInteger(0);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            Long userId = (long) i;
+            executorService.submit(() -> {
+                try {
+                    reservationService.reservation(userId, concertScheduleId, seatId);
+                    successfulReservations.incrementAndGet();
+                } catch (Exception e) {
+                    failedReservations.incrementAndGet();
+                    System.out.println("Optimistic Lock Exception occurred: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        //then
+        assertThat(successfulReservations.get()).isEqualTo(1);
+        assertThat(failedReservations.get()).isEqualTo(numberOfThreads - 1);
+    }
+}

--- a/src/test/java/concertreservation/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/concertreservation/reservation/service/ReservationServiceTest.java
@@ -1,0 +1,93 @@
+package concertreservation.reservation.service;
+
+import concertreservation.common.exception.CustomGlobalException;
+import concertreservation.common.exception.ErrorType;
+import concertreservation.concert.entity.Concert;
+import concertreservation.concert.entity.ConcertSchedule;
+import concertreservation.concert.entity.Seat;
+import concertreservation.concert.entity.SeatStatus;
+import concertreservation.concert.service.ConcertRepository;
+import concertreservation.concert.service.ConcertScheduleRepository;
+import concertreservation.concert.service.SeatRepository;
+import concertreservation.reservation.service.response.ReservationResponse;
+import concertreservation.user.service.UserRepository;
+import concertreservation.user.service.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @InjectMocks
+    private ReservationService reservationService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ConcertRepository concertRepository;
+    @Mock
+    private ConcertScheduleRepository concertScheduleRepository;
+    @Mock
+    private ReservationRepository reservationRepository;
+    @Mock
+    private SeatRepository seatRepository;
+
+    @Test
+    @DisplayName("좌석 예약이 완료되고 응답값을 확인한다. ")
+    void reservation() {
+        //given
+        long userId = 1L;
+        long concertId = 1L;
+        long seatId = 1L;
+        long concertScheduleId = 1L;
+
+        given(userRepository.findById(concertId))
+                .willReturn(Optional.of(new User(userId, "이름1", "번호1", 50000)));
+        given(concertScheduleRepository.findById(concertId))
+                .willReturn(Optional.of(new ConcertSchedule(concertScheduleId, LocalDate.of(2025, 1, 15))));
+        given(concertRepository.findById(concertId))
+                .willReturn(Optional.of(new Concert(concertId, "콘서트1", "아이유", "https://")));
+        given(seatRepository.findByIdWithOptimisticLock(seatId))
+                .willReturn(Optional.of(new Seat(seatId, concertScheduleId, "A1", SeatStatus.AVAILABLE, 50000, null)));
+        //when
+        ReservationResponse response = reservationService.reservation(userId, concertScheduleId, seatId);
+        //then
+        assertThat(response)
+                .extracting("title", "concertDate", "singerName")
+                .containsExactlyInAnyOrder("콘서트1", LocalDate.of(2025, 1, 15), "아이유");
+    }
+
+    @Test
+    @DisplayName("좌석을 예약할때 이미 예약된 좌석일때 예외가 발생한다.")
+    void reservationFailWith() {
+        //given
+        long userId = 1L;
+        long concertId = 1L;
+        long seatId = 1L;
+        long concertScheduleId = 1L;
+
+        given(userRepository.findById(concertId))
+                .willReturn(Optional.of(new User(userId, "이름1", "번호1", 50000)));
+        given(concertScheduleRepository.findById(concertId))
+                .willReturn(Optional.of(new ConcertSchedule(concertScheduleId, LocalDate.of(2025, 1, 15))));
+        given(concertRepository.findById(concertId))
+                .willReturn(Optional.of(new Concert(concertId, "콘서트1", "아이유", "https://")));
+        given(seatRepository.findByIdWithOptimisticLock(seatId))
+                .willReturn(Optional.of(new Seat(seatId, concertScheduleId, "A1", SeatStatus.RESERVED, 50000, null)));
+        //when
+        //then
+        assertThatThrownBy(() -> reservationService.reservation(userId, concertScheduleId, seatId))
+                .isInstanceOf(CustomGlobalException.class)
+                .hasMessage(ErrorType.ALREADY_RESERVED_SEAT.getMessage());
+    }
+}


### PR DESCRIPTION
좌석 예약 요청 API
- 좌석 예약과 동시에 해당 좌석은 그 유저에게 약 5분간 임시 배정

좌석 예약으로 낙관적 락을 선택한 이유 
- 콘서트 예약의 경우, 이미 예약된 좌석을 다시 예약하려는 시도는 드물기 때문에 추후에 경합이 줄어들게 됩니다. 동시 경합 시에는 '이미 선점된 좌석'에 대해 예약 실패한 사용자에게 빠른 피드백을 제공하여 즉시 다른 좌석을 예약하도록 유도하는 것이 비즈니스적으로 중요하다고 판단됩니다. 경합이 대개 초기에 집중되며, 이후에는 자원의 상태가 안정화되기 때문에 낙관적 락이 최적의 선택이라고 생각되었습니다.