### PR TITLE
[#17]feat: 오래 걸리는 쿼리 확인 후 인덱스 적용

### DIFF
--- a/src/main/java/concertreservation/concert/entity/ConcertSchedule.java
+++ b/src/main/java/concertreservation/concert/entity/ConcertSchedule.java
@@ -12,7 +12,10 @@ import java.time.LocalDate;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "concert_schedules")
+@Table(name = "concert_schedules", indexes = {
+        @Index(name = "idx_concert_schedule_concert_id",
+                columnList = "concert_id")
+})
 public class ConcertSchedule {
 
     @Id

--- a/src/main/java/concertreservation/concert/entity/Seat.java
+++ b/src/main/java/concertreservation/concert/entity/Seat.java
@@ -11,7 +11,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "seats")
+@Table(name = "seats", indexes = {
+        @Index(name = "idx_seat_schedule_status",
+                columnList = "concert_schedule_id,seat_status")
+})
 public class Seat {
 
     @Id
@@ -53,11 +56,11 @@ public class Seat {
         }
     }
 
-    public boolean isAvailableSeat(){
+    public boolean isAvailableSeat() {
         return this.seatStatus == SeatStatus.AVAILABLE;
     }
 
-    public void updateSeatStatus(SeatStatus seatStatus){
+    public void updateSeatStatus(SeatStatus seatStatus) {
         this.seatStatus = seatStatus;
     }
 }


### PR DESCRIPTION
테스트 데이터

유저 (100만건)
콘서트 (200만건)
콘서트 스케줄 (299만 8842건)
좌석 (스케줄 id당 50개 - 총 1억 4994만 2100건)
예약 가능 날짜 조회 api

인덱스 적용 전 (3890ms)
인덱스 적용 후 (29ms)
예약 좌석 조회 api

인덱스 적용 전 (294,960ms)
인덱스 적용 후 (747ms)