### PR TITLE
mysql 기반 대기열 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/concertreservation/ConcertReservationApplication.java
+++ b/src/main/java/concertreservation/ConcertReservationApplication.java
@@ -2,7 +2,9 @@ package concertreservation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class ConcertReservationApplication {
 

--- a/src/main/java/concertreservation/common/config/WebConfig.java
+++ b/src/main/java/concertreservation/common/config/WebConfig.java
@@ -1,0 +1,19 @@
+package concertreservation.common.config;
+
+import concertreservation.token.interceptor.WaitingTokenInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final WaitingTokenInterceptor waitingTokenInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(waitingTokenInterceptor);
+    }
+}

--- a/src/main/java/concertreservation/common/exception/ErrorResponse.java
+++ b/src/main/java/concertreservation/common/exception/ErrorResponse.java
@@ -1,0 +1,16 @@
+package concertreservation.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private int code;
+    private String message;
+
+    public static ErrorResponse of(ErrorType errorType) {
+        return new ErrorResponse(errorType.getStatus(), errorType.getMessage());
+    }
+}

--- a/src/main/java/concertreservation/common/exception/ErrorType.java
+++ b/src/main/java/concertreservation/common/exception/ErrorType.java
@@ -18,7 +18,13 @@ public enum ErrorType {
     EXPIRED_RESERVATION(400, "예약 만료 시간이 지났습니다. 다시 예약하여 주세요"),
     NOT_ENOUGH_POINT(400,"포인트가 부족합니다. 충전후 결제하여 주세요."),
     JSON_PARSING_FAILED(500,"json 변환에 실패하였습니다."),
-    ALREADY_EXIST_SCHEDULE(400,"이미 콘서트 스케줄이 존재합니다.")
+    ALREADY_EXIST_SCHEDULE(400,"이미 콘서트 스케줄이 존재합니다."),
+    ALREADY_EXIST_ACTIVE_TOKEN(400,"이미 대기중이거나 활성화된 토큰이 존재합니다."),
+
+    INVALID_TOKEN(400,"유효하지 않은 토큰입니다."),
+    NOT_FOUND_TOKEN(400,"토큰을 찾을 수 없습니다."),
+    EXPIRED_TOKEN(400,"토큰이 만료되었습니다."),
+    TOKEN_NOT_ACTIVE(400,"토큰이 활성화되어 있지 않습니다.")
     ;
 
     private final int status;

--- a/src/main/java/concertreservation/concert/controller/ConcertController.java
+++ b/src/main/java/concertreservation/concert/controller/ConcertController.java
@@ -5,6 +5,7 @@ import concertreservation.concert.service.ConcertService;
 import concertreservation.concert.service.response.ConcertAvailableDateResponse;
 import concertreservation.concert.service.response.ConcertAvailableSeatResponse;
 import concertreservation.concert.service.response.ConcertListResponse;
+import concertreservation.token.interceptor.WaitingTokenRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,11 +23,13 @@ public class ConcertController {
         return concertService.concerts(pageSize,lastConcertId);
     }
 
+    @WaitingTokenRequired
     @GetMapping("/concerts/{concertId}/schedule")
     public ConcertAvailableDateResponse availableDate(@PathVariable Long concertId) {
         return concertService.availableDate(concertId);
     }
 
+    @WaitingTokenRequired
     @GetMapping("/concerts/seats/{concertScheduleId}")
     public ConcertAvailableSeatResponse availableSeat(@PathVariable Long concertScheduleId) {
         return concertService.availableSeat(concertScheduleId);

--- a/src/main/java/concertreservation/reservation/controller/ReservationController.java
+++ b/src/main/java/concertreservation/reservation/controller/ReservationController.java
@@ -4,6 +4,7 @@ import concertreservation.reservation.controller.request.ConcertSeatReservationR
 import concertreservation.reservation.service.ReservationService;
 import concertreservation.reservation.service.response.PaymentResponse;
 import concertreservation.reservation.service.response.ReservationResponse;
+import concertreservation.token.interceptor.WaitingTokenRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,11 +16,13 @@ public class ReservationController {
 
     private final ReservationService reservationService;
 
+    @WaitingTokenRequired
     @PostMapping("/concerts/reservation")
     public ReservationResponse reservation(@RequestBody ConcertSeatReservationRequest request){
         return reservationService.reservation(request.getUserId(), request.getConcertScheduleId(), request.getSeatId());
     }
 
+    @WaitingTokenRequired
     @PostMapping("/concerts/payment")
     public PaymentResponse payment(@RequestBody Long reservationId){
         return reservationService.payment(reservationId);

--- a/src/main/java/concertreservation/token/controller/TokenController.java
+++ b/src/main/java/concertreservation/token/controller/TokenController.java
@@ -1,0 +1,26 @@
+package concertreservation.token.controller;
+
+import concertreservation.token.interceptor.WaitingTokenRequired;
+import concertreservation.token.service.WaitingTokenService;
+import concertreservation.token.service.response.TokenIssueResponse;
+import concertreservation.token.service.response.TokenStatusResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final WaitingTokenService waitingTokenService;
+
+    @PostMapping("/waiting-token")
+    public TokenIssueResponse issueToken(@RequestParam Long userId) {
+        return waitingTokenService.issueToken(userId);
+    }
+
+    @WaitingTokenRequired
+    @GetMapping("/waiting-token/status")
+    public TokenStatusResponse getTokenStatus(@RequestHeader("WaitingToken") String token) {
+        return waitingTokenService.getTokenStatus(token);
+    }
+}

--- a/src/main/java/concertreservation/token/entity/TokenStatus.java
+++ b/src/main/java/concertreservation/token/entity/TokenStatus.java
@@ -1,0 +1,16 @@
+package concertreservation.token.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenStatus {
+
+    ACTIVE("활성중"),
+    WAITING("대기중"),
+    EXPIRED("만료됨")
+    ;
+
+    private final String content;
+}

--- a/src/main/java/concertreservation/token/entity/WaitingToken.java
+++ b/src/main/java/concertreservation/token/entity/WaitingToken.java
@@ -1,0 +1,56 @@
+package concertreservation.token.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "waiting_tokens")
+public class WaitingToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    private TokenStatus status;
+    private LocalDateTime issuedAt;
+    private LocalDateTime expiredAt;
+
+    public static WaitingToken create(Long userId, String token, int expireMinute) {
+        WaitingToken waitingToken = new WaitingToken();
+        waitingToken.userId = userId;
+        waitingToken.token = token;
+        waitingToken.status = TokenStatus.WAITING;
+        LocalDateTime now = LocalDateTime.now();
+        waitingToken.issuedAt = now;
+        waitingToken.expiredAt = now.plusMinutes(expireMinute);
+        return waitingToken;
+    }
+
+    public void updateStatus(TokenStatus tokenStatus, int expireMinute) {
+        this.status = tokenStatus;
+        if (tokenStatus == TokenStatus.ACTIVE) {
+            this.expiredAt = LocalDateTime.now().plusMinutes(expireMinute);
+        }
+    }
+
+    public boolean isExpired() {
+        return this.getStatus() == TokenStatus.EXPIRED;
+    }
+
+    public boolean isWaiting() {
+        return this.getStatus() == TokenStatus.WAITING;
+    }
+}

--- a/src/main/java/concertreservation/token/interceptor/WaitingTokenInterceptor.java
+++ b/src/main/java/concertreservation/token/interceptor/WaitingTokenInterceptor.java
@@ -1,0 +1,69 @@
+package concertreservation.token.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import concertreservation.common.exception.CustomGlobalException;
+import concertreservation.common.exception.ErrorResponse;
+import concertreservation.common.exception.ErrorType;
+import concertreservation.token.service.TokenProvider;
+import concertreservation.token.service.WaitingTokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingTokenInterceptor implements HandlerInterceptor {
+
+    private final TokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        WaitingTokenRequired annotation = handlerMethod.getMethodAnnotation(WaitingTokenRequired.class);
+
+        if (annotation == null) {
+            return true;
+        }
+
+        try {
+            String token = extractToken(request);
+            validateQueueToken(token);
+            return true;
+        } catch (CustomGlobalException e) {
+            handleException(response, e);
+            return false;
+        }
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String token = request.getHeader("WaitingToken");
+        if (token == null || token.isEmpty()) {
+            throw new CustomGlobalException(ErrorType.NOT_FOUND_TOKEN);
+        }
+        return token;
+    }
+
+    private void validateQueueToken(String token) {
+        if (!jwtTokenProvider.validateToken(token)) {
+            throw new CustomGlobalException(ErrorType.INVALID_TOKEN);
+        }
+    }
+
+    private void handleException(HttpServletResponse response, CustomGlobalException e) throws IOException {
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorType());
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/concertreservation/token/interceptor/WaitingTokenRequired.java
+++ b/src/main/java/concertreservation/token/interceptor/WaitingTokenRequired.java
@@ -1,0 +1,11 @@
+package concertreservation.token.interceptor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WaitingTokenRequired {
+}

--- a/src/main/java/concertreservation/token/repository/WaitingTokenRepositoryImpl.java
+++ b/src/main/java/concertreservation/token/repository/WaitingTokenRepositoryImpl.java
@@ -1,0 +1,78 @@
+package concertreservation.token.repository;
+
+import concertreservation.token.entity.TokenStatus;
+import concertreservation.token.entity.WaitingToken;
+import concertreservation.token.service.WaitingTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class WaitingTokenRepositoryImpl implements WaitingTokenRepository {
+
+    private final WaitingTokenjJpaRepository waitingTokenjJpaRepository;
+
+    @Override
+    public Optional<WaitingToken> findById(Long tokenId) {
+        return waitingTokenjJpaRepository.findById(tokenId);
+    }
+
+    @Override
+    public WaitingToken save(WaitingToken waitingToken) {
+        return waitingTokenjJpaRepository.save(waitingToken);
+    }
+
+    @Override
+    public Optional<WaitingToken> findByToken(String token) {
+        return waitingTokenjJpaRepository.findByToken(token);
+    }
+
+    @Override
+    public List<WaitingToken> findByStatusOrderByIdAsc(TokenStatus status) {
+        return waitingTokenjJpaRepository.findByStatusOrderByIdAsc(status);
+    }
+
+    @Override
+    public int countByStatus(TokenStatus status) {
+        return waitingTokenjJpaRepository.countByStatus(status);
+    }
+
+    @Override
+    public List<WaitingToken> findByStatusInAndExpiredAtBefore(List<TokenStatus> statuses, LocalDateTime now) {
+        return waitingTokenjJpaRepository.findByStatusInAndExpiredAtBefore(statuses, now);
+    }
+
+    @Override
+    public long countByStatusAndIdLessThan(TokenStatus status, Long id) {
+        return waitingTokenjJpaRepository.countByStatusAndIdLessThan(status, id);
+    }
+
+    @Override
+    public Optional<WaitingToken> findByUserIdAndStatusIn(Long userId, List<TokenStatus> statuses) {
+        return waitingTokenjJpaRepository.findByUserIdAndStatusIn(userId, statuses);
+    }
+
+    @Override
+    public void deleteByStatus(TokenStatus tokenStatus) {
+        waitingTokenjJpaRepository.deleteByStatus(tokenStatus);
+    }
+
+    @Override
+    public List<WaitingToken> findByStatus(TokenStatus tokenStatus) {
+        return waitingTokenjJpaRepository.findByStatus(tokenStatus);
+    }
+
+    @Override
+    public List<WaitingToken> saveAll(List<WaitingToken> waitingTokens) {
+        return waitingTokenjJpaRepository.saveAll(waitingTokens);
+    }
+
+    @Override
+    public List<WaitingToken> findAll() {
+        return waitingTokenjJpaRepository.findAll();
+    }
+}

--- a/src/main/java/concertreservation/token/repository/WaitingTokenjJpaRepository.java
+++ b/src/main/java/concertreservation/token/repository/WaitingTokenjJpaRepository.java
@@ -1,0 +1,20 @@
+package concertreservation.token.repository;
+
+import concertreservation.token.entity.TokenStatus;
+import concertreservation.token.entity.WaitingToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface WaitingTokenjJpaRepository extends JpaRepository<WaitingToken,Long> {
+    Optional<WaitingToken> findByToken(String token);
+    List<WaitingToken> findByStatusOrderByIdAsc(TokenStatus status);
+    int countByStatus(TokenStatus status);
+    List<WaitingToken> findByStatusInAndExpiredAtBefore(List<TokenStatus> statuses, LocalDateTime now);
+    long countByStatusAndIdLessThan(TokenStatus status,Long id);
+    Optional<WaitingToken> findByUserIdAndStatusIn(Long userId, List<TokenStatus> statuses);
+    void deleteByStatus(TokenStatus tokenStatus);
+    List<WaitingToken> findByStatus(TokenStatus tokenStatus);
+}

--- a/src/main/java/concertreservation/token/scheduler/TokenScheduler.java
+++ b/src/main/java/concertreservation/token/scheduler/TokenScheduler.java
@@ -1,0 +1,28 @@
+package concertreservation.token.scheduler;
+
+import concertreservation.token.service.WaitingTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenScheduler {
+
+    private final WaitingTokenService waitingTokenService;
+
+    @Scheduled(fixedRate = 60000)
+    public void updateExpiredTokenStatus(){
+        waitingTokenService.updateExpiredTokenStatus();
+    }
+
+    @Scheduled(fixedRate = 60000)
+    public void activateFromWaiting(){
+        waitingTokenService.updateActivateFromWaiting();
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void removeExpiredTokens(){
+        waitingTokenService.removeExpiredTokens();
+    }
+}

--- a/src/main/java/concertreservation/token/service/TokenProvider.java
+++ b/src/main/java/concertreservation/token/service/TokenProvider.java
@@ -1,0 +1,61 @@
+package concertreservation.token.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class TokenProvider {
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    private static final long JWT_TOKEN_VALIDITY = 24 * 60 * 60 * 1000; // 24시간
+
+    public String createToken(Long userId) {
+        Claims claims = Jwts.claims();
+        claims.put("userId", userId);
+        claims.put("type", "WAITING_TOKEN");
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.get("userId", Long.class);
+    }
+
+    private Key getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/concertreservation/token/service/WaitingTokenRepository.java
+++ b/src/main/java/concertreservation/token/service/WaitingTokenRepository.java
@@ -1,0 +1,26 @@
+package concertreservation.token.service;
+
+import concertreservation.token.entity.TokenStatus;
+import concertreservation.token.entity.WaitingToken;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface WaitingTokenRepository {
+
+    Optional<WaitingToken> findById(Long tokenId);
+    WaitingToken save(WaitingToken waitingToken);
+    Optional<WaitingToken> findByToken(String token);
+    List<WaitingToken> findByStatusOrderByIdAsc(TokenStatus status);
+    int countByStatus(TokenStatus status);
+    List<WaitingToken> findByStatusInAndExpiredAtBefore(List<TokenStatus> statuses, LocalDateTime now);
+    long countByStatusAndIdLessThan(TokenStatus status,Long id);
+    Optional<WaitingToken> findByUserIdAndStatusIn(Long userId, List<TokenStatus> statuses);
+    void deleteByStatus(TokenStatus tokenStatus);
+
+    List<WaitingToken> findByStatus(TokenStatus tokenStatus);
+    List<WaitingToken> saveAll(List<WaitingToken> waitingTokens);
+    List<WaitingToken> findAll();
+
+}

--- a/src/main/java/concertreservation/token/service/WaitingTokenService.java
+++ b/src/main/java/concertreservation/token/service/WaitingTokenService.java
@@ -1,0 +1,103 @@
+package concertreservation.token.service;
+
+import concertreservation.common.exception.CustomGlobalException;
+import concertreservation.common.exception.ErrorType;
+import concertreservation.token.entity.TokenStatus;
+import concertreservation.token.entity.WaitingToken;
+import concertreservation.token.service.response.TokenIssueResponse;
+import concertreservation.token.service.response.TokenStatusResponse;
+import concertreservation.token.util.TokenUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WaitingTokenService {
+
+    private final TokenProvider tokenProvider;
+    private final WaitingTokenRepository waitingTokenRepository;
+
+    @Transactional
+    public TokenIssueResponse issueToken(Long userId) {
+
+        // 이렇게 해주지 않으면 대기 순서를 waiting 개수로 계산하는데 새로 발급받는 것이 계속 waiting 상태로 계속 쌓여서
+        // 기존것을 expired 시켜줘야함
+        waitingTokenRepository.findByUserIdAndStatusIn(
+                userId,
+                List.of(TokenStatus.ACTIVE, TokenStatus.WAITING)
+        ).ifPresent(token -> {
+            token.updateStatus(TokenStatus.EXPIRED, 0);
+            waitingTokenRepository.save(token);
+        });
+
+        String jwtToken = tokenProvider.createToken(userId);
+        WaitingToken waitingToken = waitingTokenRepository.save(WaitingToken.create(userId, jwtToken, TokenUtil.EXPIRE_MINUTE));
+
+        return TokenIssueResponse.from(jwtToken, waitingToken.getStatus());
+    }
+
+    @Transactional(readOnly = true)
+    public TokenStatusResponse getTokenStatus(String token) {
+
+        WaitingToken waitingToken = waitingTokenRepository.findByToken(token)
+                .orElseThrow(() -> new CustomGlobalException(ErrorType.NOT_FOUND_TOKEN));
+
+        if (waitingToken.isExpired()) {
+            return TokenStatusResponse.from(waitingToken, null);
+        }
+
+        if (waitingToken.isWaiting()) {
+            long waitingStatusSize = waitingTokenRepository.countByStatusAndIdLessThan(
+                    TokenStatus.WAITING,
+                    waitingToken.getId()
+            );
+            Long waitingNumber = waitingStatusSize + 1;
+            return TokenStatusResponse.from(waitingToken, waitingNumber);
+        }
+
+        return TokenStatusResponse.from(waitingToken, 0L);
+    }
+
+    @Transactional
+    public void updateExpiredTokenStatus() {
+
+        List<WaitingToken> expiredTokens = waitingTokenRepository.findByStatusInAndExpiredAtBefore(
+                Arrays.asList(TokenStatus.ACTIVE),
+                LocalDateTime.now()
+        );
+
+        for (WaitingToken token : expiredTokens) {
+            token.updateStatus(TokenStatus.EXPIRED, 0);
+        }
+    }
+
+    @Transactional
+    public void updateActivateFromWaiting() {
+        int currentActiveCount = waitingTokenRepository.countByStatus(TokenStatus.ACTIVE);
+        int availableSlots = TokenUtil.MAX_ACTIVE_TOKENS - currentActiveCount;
+
+        if (availableSlots <= 0) {
+            return;
+        }
+
+        List<WaitingToken> waitingTokens = waitingTokenRepository.findByStatusOrderByIdAsc(TokenStatus.WAITING)
+                .stream()
+                .limit(availableSlots)
+                .toList();
+
+        for (WaitingToken token : waitingTokens) {
+            token.updateStatus(TokenStatus.ACTIVE, TokenUtil.EXPIRE_MINUTE);
+            waitingTokenRepository.save(token);
+        }
+    }
+
+    @Transactional
+    public void removeExpiredTokens() {
+        waitingTokenRepository.deleteByStatus(TokenStatus.EXPIRED);
+    }
+}

--- a/src/main/java/concertreservation/token/service/response/TokenIssueResponse.java
+++ b/src/main/java/concertreservation/token/service/response/TokenIssueResponse.java
@@ -1,0 +1,19 @@
+package concertreservation.token.service.response;
+
+import concertreservation.token.entity.TokenStatus;
+import lombok.Getter;
+
+@Getter
+public class TokenIssueResponse {
+
+   private String token;
+   private TokenStatus tokenStatus;
+
+
+    public static TokenIssueResponse from(String jwtToken, TokenStatus status) {
+        TokenIssueResponse response = new TokenIssueResponse();
+        response.token = jwtToken;
+        response.tokenStatus = status;
+        return response;
+    }
+}

--- a/src/main/java/concertreservation/token/service/response/TokenStatusResponse.java
+++ b/src/main/java/concertreservation/token/service/response/TokenStatusResponse.java
@@ -1,0 +1,25 @@
+package concertreservation.token.service.response;
+
+import concertreservation.token.entity.TokenStatus;
+import concertreservation.token.entity.WaitingToken;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TokenStatusResponse {
+
+    private String token;
+    private TokenStatus tokenStatus;
+    private Long waitingNumber;
+    private LocalDateTime expiredAt;
+
+    public static TokenStatusResponse from(WaitingToken waitingToken, Long waitingNumber) {
+        TokenStatusResponse response = new TokenStatusResponse();
+        response.token = waitingToken.getToken();
+        response.tokenStatus = waitingToken.getStatus();
+        response.waitingNumber = waitingNumber;
+        response.expiredAt = waitingToken.getExpiredAt();
+        return response;
+    }
+}

--- a/src/main/java/concertreservation/token/util/TokenUtil.java
+++ b/src/main/java/concertreservation/token/util/TokenUtil.java
@@ -1,0 +1,6 @@
+package concertreservation.token.util;
+
+public interface TokenUtil {
+    int EXPIRE_MINUTE = 20;
+    int MAX_ACTIVE_TOKENS = 700;
+}

--- a/src/test/java/concertreservation/concert/service/ConcertServiceTest.java
+++ b/src/test/java/concertreservation/concert/service/ConcertServiceTest.java
@@ -32,6 +32,9 @@ class ConcertServiceTest {
     private ConcertScheduleRepository concertScheduleRepository;
 
     @Mock
+    private ConcertRedisRepository concertRedisRepository;
+
+    @Mock
     private ConcertRepository concertRepository;
 
     @Mock

--- a/src/test/java/concertreservation/token/interceptor/WaitingTokenInterceptorTest.java
+++ b/src/test/java/concertreservation/token/interceptor/WaitingTokenInterceptorTest.java
@@ -1,0 +1,51 @@
+package concertreservation.token.interceptor;
+
+import concertreservation.token.service.WaitingTokenService;
+import concertreservation.token.service.response.TokenIssueResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WaitingTokenInterceptorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WaitingTokenService waitingTokenService;
+
+    @Test
+    @DisplayName("유효한 토큰으로 요청 시 정상 처리되어야 한다")
+    void validTokenAccess() throws Exception {
+        // given
+        TokenIssueResponse tokenResponse = waitingTokenService.issueToken(1L);
+
+        // when & then
+        mockMvc.perform(get("/waiting-token/status")
+                        .header("WaitingToken", tokenResponse.getToken()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 요청 시 401 에러가 반환되어야 한다")
+    void invalidTokenAccess() throws Exception {
+        mockMvc.perform(get("/waiting-token/status")
+                        .header("WaitingToken", "invalid-token"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 시 401 에러가 반환되어야 한다")
+    void noTokenAccess() throws Exception {
+        mockMvc.perform(get("/waiting-token/status"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/concertreservation/token/scheduler/TokenSchedulerTest.java
+++ b/src/test/java/concertreservation/token/scheduler/TokenSchedulerTest.java
@@ -1,0 +1,122 @@
+package concertreservation.token.scheduler;
+
+import concertreservation.token.entity.TokenStatus;
+import concertreservation.token.entity.WaitingToken;
+import concertreservation.token.service.WaitingTokenRepository;
+import concertreservation.token.util.TokenUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class TokenSchedulerTest {
+
+    @Autowired
+    private TokenScheduler tokenScheduler;
+
+    @Autowired
+    private WaitingTokenRepository waitingTokenRepository;
+
+    @Test
+    @DisplayName("스케줄러를 실행하면 만료된 토큰의 상태가 EXPIRED로 변경되어야 한다")
+    void updateExpiredTokenStatus() {
+        // given
+        WaitingToken token = WaitingToken.create(1L, "token", 0);
+        token.updateStatus(TokenStatus.ACTIVE, 0);
+        waitingTokenRepository.save(token);
+
+        // when
+        tokenScheduler.updateExpiredTokenStatus(); // 즉시 실행됨
+
+        // then
+        WaitingToken updatedToken = waitingTokenRepository.findById(token.getId()).orElseThrow();
+        assertThat(updatedToken.getStatus()).isEqualTo(TokenStatus.EXPIRED);
+    }
+
+    @Test
+    @DisplayName("ACTIVE 토큰 MAX 값을 5라고 가정할 때 ACTIVE 토큰 2개 생성하고 " +
+            "WAITING 토큰 4개 생성할때 스케줄러를 실행하면 ACTIVE 토큰은 5개 WAITING 토큰은 1개여야 한다")
+    void activateFromWaiting() {
+        // given
+        WaitingToken activeToken1 = WaitingToken.create(1L, "token1", TokenUtil.EXPIRE_MINUTE);
+        activeToken1.updateStatus(TokenStatus.ACTIVE, TokenUtil.EXPIRE_MINUTE);
+        WaitingToken activeToken2 = WaitingToken.create(2L, "token2", TokenUtil.EXPIRE_MINUTE);
+        activeToken2.updateStatus(TokenStatus.ACTIVE, TokenUtil.EXPIRE_MINUTE);
+
+        WaitingToken waitingToken1 = WaitingToken.create(3L, "token3", TokenUtil.EXPIRE_MINUTE);
+        WaitingToken waitingToken2 = WaitingToken.create(4L, "token4", TokenUtil.EXPIRE_MINUTE);
+        WaitingToken waitingToken3 = WaitingToken.create(5L, "token5", TokenUtil.EXPIRE_MINUTE);
+        WaitingToken waitingToken4 = WaitingToken.create(6L, "token6", TokenUtil.EXPIRE_MINUTE);
+
+        waitingTokenRepository.saveAll(Arrays.asList(
+                activeToken1, activeToken2,
+                waitingToken1, waitingToken2, waitingToken3, waitingToken4
+        ));
+
+        // when
+        tokenScheduler.activateFromWaiting();
+
+        // then
+        List<WaitingToken> activeTokens = waitingTokenRepository.findByStatus(TokenStatus.ACTIVE);
+        assertThat(activeTokens).hasSize(5);
+
+        List<WaitingToken> waitingTokens = waitingTokenRepository.findByStatus(TokenStatus.WAITING);
+        assertThat(waitingTokens.size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("EXPIRED 상태의 토큰들이 삭제되어야 한다")
+    void removeExpiredTokens() {
+        // given
+        // ACTIVE, WAITING 토큰 생성
+        WaitingToken activeToken = WaitingToken.create(1L, "token1", TokenUtil.EXPIRE_MINUTE);
+        activeToken.updateStatus(TokenStatus.ACTIVE, TokenUtil.EXPIRE_MINUTE);
+        WaitingToken waitingToken = WaitingToken.create(2L, "token2", TokenUtil.EXPIRE_MINUTE);
+
+        // EXPIRED 토큰 생성
+        WaitingToken expiredToken1 = WaitingToken.create(3L, "token3", 0);
+        expiredToken1.updateStatus(TokenStatus.EXPIRED, 0);
+        WaitingToken expiredToken2 = WaitingToken.create(4L, "token4", 0);
+        expiredToken2.updateStatus(TokenStatus.EXPIRED, 0);
+
+        waitingTokenRepository.saveAll(Arrays.asList(
+                activeToken, waitingToken, expiredToken1, expiredToken2
+        ));
+
+        // when
+        tokenScheduler.removeExpiredTokens();
+
+        // then
+        List<WaitingToken> remainingTokens = waitingTokenRepository.findAll();
+        assertThat(remainingTokens)
+                .hasSize(2)
+                .extracting("status")
+                .containsOnly(TokenStatus.ACTIVE, TokenStatus.WAITING);
+    }
+
+    @TestConfiguration
+    static class TestTokenConfig {
+        @Bean
+        public TokenUtil tokenUtil() {
+            return new TokenUtil() {
+                public int getMaxActiveTokens() {
+                    return 5;
+                }
+
+                public int getExpireMinute() {
+                    return 5;
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/concertreservation/token/service/TokenProviderTest.java
+++ b/src/test/java/concertreservation/token/service/TokenProviderTest.java
@@ -1,0 +1,61 @@
+package concertreservation.token.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class TokenProviderTest {
+
+    @InjectMocks
+    private TokenProvider tokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(tokenProvider, "secretKey", "dasdsadasdasdasdasdsadasdasdasdasdasdsadasdas");
+    }
+
+    @Test
+    @DisplayName("토큰 생성 시 유효한 토큰이 생성되어야 한다")
+    void createToken() {
+        //given
+        Long userId = 1L;
+        //when
+        String token = tokenProvider.createToken(userId);
+        //then
+        assertThat(token).isNotNull();
+        assertThat(tokenProvider.validateToken(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("토큰을 생성하면 그 토큰에는 발급된 userId를 추출할수 있어야 한다.")
+    void createTokenEqualUserId() {
+        //given
+        Long userId = 1L;
+        //when
+        String token = tokenProvider.createToken(userId);
+        //then
+        assertThat(token).isNotNull();
+        assertThat(tokenProvider.getUserIdFromToken(token)).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰 검증 시 false를 반환해야 한다")
+    void validateInvalidToken() {
+        //given
+        String invalidToken = "invalidToken";
+        //when
+        boolean result = tokenProvider.validateToken(invalidToken);
+        //then
+        assertThat(result).isFalse();
+    }
+
+}

--- a/src/test/java/concertreservation/token/service/WaitingTokenServiceTest.java
+++ b/src/test/java/concertreservation/token/service/WaitingTokenServiceTest.java
@@ -1,0 +1,98 @@
+package concertreservation.token.service;
+
+import concertreservation.token.entity.TokenStatus;
+import concertreservation.token.entity.WaitingToken;
+import concertreservation.token.service.response.TokenIssueResponse;
+import concertreservation.token.service.response.TokenStatusResponse;
+import concertreservation.token.util.TokenUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WaitingTokenServiceTest {
+
+    @InjectMocks
+    private WaitingTokenService waitingTokenService;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private WaitingTokenRepository waitingTokenRepository;
+
+    @Test
+    @DisplayName("토큰 발급 시 새로운 대기 토큰이 생성되어야 하고 WAITING상태여야 한다.")
+    void issueToken() {
+        //given
+        Long userId = 1L;
+        String jwtToken = "test-token";
+        WaitingToken waitingToken = WaitingToken.create(userId, jwtToken, TokenUtil.EXPIRE_MINUTE);
+
+        given(tokenProvider.createToken(userId)).willReturn(jwtToken);
+        given(waitingTokenRepository.save(any(WaitingToken.class))).willReturn(waitingToken);
+        //when
+        TokenIssueResponse response = waitingTokenService.issueToken(userId);
+        //then
+        assertThat(response.getToken()).isEqualTo(jwtToken);
+        assertThat(response.getTokenStatus()).isEqualTo(TokenStatus.WAITING);
+        verify(waitingTokenRepository).findByUserIdAndStatusIn(eq(userId), any());
+    }
+
+    @Test
+    @DisplayName("대기 상태의 토큰 조회 시 대기 순번이 반환되어야 한다")
+    void getWaitingTokenStatus() {
+        //given
+        String token = "test-token";
+
+        WaitingToken waitingToken = WaitingToken.create(1L, token, TokenUtil.EXPIRE_MINUTE);
+        given(waitingTokenRepository.findByToken(token)).willReturn(Optional.of(waitingToken));
+        given(waitingTokenRepository.countByStatusAndIdLessThan(TokenStatus.WAITING, waitingToken.getId()))
+                .willReturn(5L);
+        //when
+        TokenStatusResponse response = waitingTokenService.getTokenStatus(token);
+        //then
+        assertThat(response).extracting("token", "tokenStatus", "waitingNumber")
+                .containsExactlyInAnyOrder(token, TokenStatus.WAITING, 5L + 1);
+    }
+
+    @Test
+    @DisplayName("대기 상태의 만료 토큰 조회 시 대기 순번은 null이 반환되어야 한다.")
+    void getExpiredWaitingTokenStatus(){
+        //given
+        String token = "test-token";
+
+        WaitingToken waitingToken = WaitingToken.builder().userId(1L).token(token).status(TokenStatus.EXPIRED).build();
+        given(waitingTokenRepository.findByToken(token)).willReturn(Optional.of(waitingToken));
+        //when
+        TokenStatusResponse response = waitingTokenService.getTokenStatus(token);
+        //then
+        assertThat(response).extracting("token", "tokenStatus", "waitingNumber")
+                .containsExactlyInAnyOrder(token, TokenStatus.EXPIRED, null);
+    }
+
+    @Test
+    @DisplayName("대기 상태의 활성 토큰 조회 시 대기 순번은 0이 반환되어야 한다.")
+    void getActiveWaitingTokenStatus(){
+        //given
+        String token = "test-token";
+
+        WaitingToken waitingToken = WaitingToken.builder().userId(1L).token(token).status(TokenStatus.ACTIVE).build();
+        given(waitingTokenRepository.findByToken(token)).willReturn(Optional.of(waitingToken));
+        //when
+        TokenStatusResponse response = waitingTokenService.getTokenStatus(token);
+        //then
+        assertThat(response).extracting("token", "tokenStatus", "waitingNumber")
+                .containsExactlyInAnyOrder(token, TokenStatus.ACTIVE, 0L);
+    }
+}

--- a/src/test/java/concertreservation/user/controller/UserControllerTest.java
+++ b/src/test/java/concertreservation/user/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package concertreservation.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import concertreservation.token.interceptor.WaitingTokenInterceptor;
 import concertreservation.user.controller.request.PointChargeRequest;
 import concertreservation.user.service.UserService;
 import concertreservation.user.service.entity.User;
@@ -28,6 +29,9 @@ class UserControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @MockitoBean
+    private WaitingTokenInterceptor waitingTokenInterceptor;
 
     @Test
     @DisplayName("포인트를 조회한다.")


### PR DESCRIPTION
# 대기열 흐름
- 사용자가 콘서트를 조회한다
- 콘서트를 선택하고 예매하기 버튼을 누르면 WAITING 토큰 발급
- 이후 포인트 조회, 포인트 충전을 제외한 api는 토큰이 필요로 한다.
- 폴링 API 시 토큰 상태와 대기번호를 반환 받을수 있고 이걸 통해 ACTIVE상태인지 구별한다.
- ACTIVE상태일 시 20분동안 예매가 가능하다.

## WAITING 상태의 토큰을 몇개의 ACTIVE상태로 전환을 해야할까에 대한 고민
- 대기열을 적용하기 전 부하테스트 결과 **1000tps**
- 서버가 안정적으로 처리할 수 있는 TPS를 80%로 설정하면 약 800 TPS가 적정선

## 스케줄러
- 만료시간이 지난 토큰을 expired로 바꿔주는 스케줄러
    - acitve 상태를 찾아서 현재시간보다 전이면 expired로 update
- waiting 상태의 토큰을 active로 바꿔주는 스케줄러
    - 서버에서 정한 active 개수 - 현재 active 개수를 구한다. (x개라고 가정)
    - 이 값이 0보다 작으면 ealry return
    - waiting상태의 토큰을 x개 limit을 걸어 차례대로 가져와 active로 전환후 저장
- 쌓여있는 expired토큰을 제거해주는 스케줄러
    - expired 토큰을 조회후 제거