### PR TITLE
[#24]feat: MySQL 기반 대기열 버그 수정

### DIFF
--- a/src/main/java/concertreservation/token/interceptor/WaitingTokenInterceptor.java
+++ b/src/main/java/concertreservation/token/interceptor/WaitingTokenInterceptor.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import concertreservation.common.exception.CustomGlobalException;
 import concertreservation.common.exception.ErrorResponse;
 import concertreservation.common.exception.ErrorType;
+import concertreservation.token.entity.TokenStatus;
+import concertreservation.token.entity.WaitingToken;
 import concertreservation.token.service.TokenProvider;
 import concertreservation.token.service.WaitingTokenService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,6 +23,7 @@ public class WaitingTokenInterceptor implements HandlerInterceptor {
 
     private final TokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
+    private final WaitingTokenService waitingTokenService;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -56,6 +59,16 @@ public class WaitingTokenInterceptor implements HandlerInterceptor {
     private void validateQueueToken(String token) {
         if (!jwtTokenProvider.validateToken(token)) {
             throw new CustomGlobalException(ErrorType.INVALID_TOKEN);
+        }
+
+        WaitingToken waitingToken = waitingTokenService.getToken(token);
+
+        if (waitingToken.getStatus() == TokenStatus.EXPIRED) {
+            throw new CustomGlobalException(ErrorType.EXPIRED_TOKEN);
+        }
+
+        if (waitingToken.getStatus() != TokenStatus.ACTIVE) {
+            throw new CustomGlobalException(ErrorType.TOKEN_NOT_ACTIVE);
         }
     }
 

--- a/src/main/java/concertreservation/token/service/WaitingTokenService.java
+++ b/src/main/java/concertreservation/token/service/WaitingTokenService.java
@@ -63,6 +63,12 @@ public class WaitingTokenService {
         return TokenStatusResponse.from(waitingToken, 0L);
     }
 
+    @Transactional(readOnly = true)
+    public WaitingToken getToken(String token){
+        return waitingTokenRepository.findByToken(token)
+                .orElseThrow(() -> new CustomGlobalException(ErrorType.NOT_FOUND_TOKEN));
+    }
+
     @Transactional
     public void updateExpiredTokenStatus() {
 

--- a/src/main/java/concertreservation/token/util/TokenUtil.java
+++ b/src/main/java/concertreservation/token/util/TokenUtil.java
@@ -2,5 +2,5 @@ package concertreservation.token.util;
 
 public interface TokenUtil {
     int EXPIRE_MINUTE = 20;
-    int MAX_ACTIVE_TOKENS = 700;
+    int MAX_ACTIVE_TOKENS = 100;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,6 @@ spring:
   redis:
     host: localhost
     port: 6379
+jwt:
+  secret:
+    key: concertkeyfsdFSDFDSVCXdsfsddvfghhtFKJSDBFKJSDJnkjbsfdhghsjk


### PR DESCRIPTION
기존
- 인터셉터에서 토큰 유효성 검증만하고 있었음.
- 하지만 토큰을 발급받고 다른 API에서 사용할때 WAIT상태여도 토큰 유효성만 검증하기에 통과될수 있다고 생각

개선
- 인터셉터에서 EXPIRED 상태면 예외, ACTIVE상태가 아니면 예외