### PR TITLE
[#30]feat: ShedLock을 통하여 서버 이중화 시 스케줄러 중복 실행 문제점 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
+	// shedlock
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.10.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/concertreservation/ConcertReservationApplication.java
+++ b/src/main/java/concertreservation/ConcertReservationApplication.java
@@ -2,9 +2,7 @@ package concertreservation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
 @SpringBootApplication
 public class ConcertReservationApplication {
 

--- a/src/main/java/concertreservation/token/scheduler/SchedulerConfig.java
+++ b/src/main/java/concertreservation/token/scheduler/SchedulerConfig.java
@@ -1,0 +1,19 @@
+package concertreservation.token.scheduler;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT50S")
+public class SchedulerConfig {
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        return new RedisLockProvider(connectionFactory);
+    }
+}

--- a/src/main/java/concertreservation/token/scheduler/TokenScheduler.java
+++ b/src/main/java/concertreservation/token/scheduler/TokenScheduler.java
@@ -3,6 +3,7 @@ package concertreservation.token.scheduler;
 import concertreservation.token.service.WaitingTokenRedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,11 @@ public class TokenScheduler {
     private static final String WAITING_QUEUE = "waiting_queue";
 
     @Scheduled(fixedRate = 60000)
+    @SchedulerLock(
+            name = "activateFromWaiting",
+            lockAtLeastFor = "PT50S",
+            lockAtMostFor = "PT50S"
+    )
     public void activateFromWaiting(){
         log.info("[Server {}] Scheduler started at {}",
                 System.getenv("HOSTNAME"), LocalDateTime.now());
@@ -32,6 +38,11 @@ public class TokenScheduler {
     }
 
     @Scheduled(cron = "0 0 0 * * *")
+    @SchedulerLock(
+            name = "removeExpiredTokens",
+            lockAtLeastFor = "PT50S",
+            lockAtMostFor = "PT50S"
+    )
     public void removeExpiredTokens(){
         Set<String> activeWaitingConcertIds = waitingTokenRedisService.getActiveWaitingConcertIds(ACTIVE_QUEUE);
 


### PR DESCRIPTION
**락 최대 유지 시간을 50초로 둔 이유**

60초로 둘 경우
- 장애 발생 시 다음 스케줄 실행에도 락이 해제되지 않을 수 있음
- 두 스케줄 실행 시점이 겹칠 수 있음

[장애 케이스]
0초: 스케줄러 A 실행 & 락 획득
30초: 서버 A 장애 발생
50초: 락 자동 해제
60초: 서버 B가 다음 스케줄 정상 실행 가능